### PR TITLE
Francois@fix quoting

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,5 +1,0 @@
-S src/
-
-B _build/src/
-
-PKG dedukti dedukti.kernel dedukti.parser dedukti.api

--- a/src/main.ml
+++ b/src/main.ml
@@ -100,6 +100,13 @@ let _ =
     })
   in
   begin
+    match !encoding with
+    | None -> ()
+    | Some (module E) -> (* The signature of the encoding should be added to the current signature *)
+      let sg = Env.get_signature cfg.env in
+      Signature.import_signature sg E.signature
+  end;
+  begin
     let cfg = Dkmeta.meta_of_files ~cfg !meta_files in
     Errors.success "Meta files parsed.";
     let post_processing env entry =


### PR DESCRIPTION
Using `--quoting` Dedukti raises an error because it does not know symbols of the encoding.